### PR TITLE
add .gitattributes file to prevent pbxproj conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj merge=union


### PR DESCRIPTION
add .gitattributes file to prevent conflicts cause by pbxproj files that is generated because of creation new files in the project. 