### PR TITLE
replace GoogleService-Info.plist file

### DIFF
--- a/IBanSaverApp-Collaboration.xcodeproj/project.pbxproj
+++ b/IBanSaverApp-Collaboration.xcodeproj/project.pbxproj
@@ -19,8 +19,8 @@
 		98428FA32B51456100040035 /* TextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98428FA22B51456100040035 /* TextFieldView.swift */; };
 		B52153BD2B51A2780008BF18 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52153BC2B51A2780008BF18 /* AuthenticationManager.swift */; };
 		B52153BF2B51A3920008BF18 /* AuthDataResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52153BE2B51A3920008BF18 /* AuthDataResultModel.swift */; };
+		B52153C12B51B5DF0008BF18 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B52153C02B51B5DF0008BF18 /* GoogleService-Info.plist */; };
 		B52B04012B5046D100BD5AD5 /* AppColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52B04002B5046D100BD5AD5 /* AppColor.swift */; };
-		B57E7FC72B516D80005E765A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B57E7FC62B516D80005E765A /* GoogleService-Info.plist */; };
 		B57E7FCA2B517B99005E765A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = B57E7FC92B517B99005E765A /* FirebaseAnalytics */; };
 		B57E7FCE2B517B99005E765A /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B57E7FCD2B517B99005E765A /* FirebaseAnalyticsSwift */; };
 		B57E7FD52B517C24005E765A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B57E7FD42B517C24005E765A /* FirebaseAuth */; };
@@ -39,8 +39,8 @@
 		98428FA22B51456100040035 /* TextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldView.swift; sourceTree = "<group>"; };
 		B52153BC2B51A2780008BF18 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		B52153BE2B51A3920008BF18 /* AuthDataResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataResultModel.swift; sourceTree = "<group>"; };
+		B52153C02B51B5DF0008BF18 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B52B04002B5046D100BD5AD5 /* AppColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColor.swift; sourceTree = "<group>"; };
-		B57E7FC62B516D80005E765A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,7 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				B52153BC2B51A2780008BF18 /* AuthenticationManager.swift */,
-				B57E7FC62B516D80005E765A /* GoogleService-Info.plist */,
+				B52153C02B51B5DF0008BF18 /* GoogleService-Info.plist */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -284,7 +284,7 @@
 			files = (
 				153B93592B4FBF84006D0F07 /* Preview Assets.xcassets in Resources */,
 				153B93562B4FBF84006D0F07 /* Assets.xcassets in Resources */,
-				B57E7FC72B516D80005E765A /* GoogleService-Info.plist in Resources */,
+				B52153C12B51B5DF0008BF18 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IBanSaverApp-Collaboration/Firebase/GoogleService-Info.plist
+++ b/IBanSaverApp-Collaboration/Firebase/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyAWhkkV560pm3swMUvWX9b1HwQPmTWJclA</string>
+	<string>AIzaSyBxQV2y58e2d1GmqxUtXfkNtO1uEYOUTFQ</string>
 	<key>GCM_SENDER_ID</key>
-	<string>156274221473</string>
+	<string>372303406628</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>SB.IBanSaverApp-Collaboration</string>
 	<key>PROJECT_ID</key>
-	<string>collaboration-iban-saver-e1ef8</string>
+	<string>collaboration-ibanserver-58d5d</string>
 	<key>STORAGE_BUCKET</key>
-	<string>collaboration-iban-saver-e1ef8.appspot.com</string>
+	<string>collaboration-ibanserver-58d5d.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:156274221473:ios:5e8948de6ccc5d53c2abe0</string>
+	<string>1:372303406628:ios:31702cdb97ab9578c9dab1</string>
 </dict>
 </plist>


### PR DESCRIPTION
Replacing the Firebase's GoogleService-Info.plist file with the correct one in order to address the invalid API Key issue. 